### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [16.x]
+                node-version: [16.x, 18.x]
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
- Add support for node 18
- Upgrade to latest GH actions