### PR TITLE
Mark @mdx-js/mdx as peer dep

### DIFF
--- a/packages/mdx-live/README.md
+++ b/packages/mdx-live/README.md
@@ -12,6 +12,12 @@ You can also provide a scope for all the variables and components used in the MD
 
 Since the v0.2.0, it's based on MDX v2. It you want to use it with MDX v1, you can look at the [v0.1.0](https://github.com/bloczjs/mdx/tree/v0.1.0).
 
+This package requires you to also install `@mdx-js/mdx`:
+
+```bash
+yarn add @mdx-js/mdx @blocz/mdx-live
+```
+
 ## ESM
 
 ⚠️ This package is only published as an ESM package, it doesn't provide any CJS exports.

--- a/packages/mdx-live/package.json
+++ b/packages/mdx-live/package.json
@@ -33,8 +33,16 @@
         "build": "rm -rf lib/ && microbundle -f modern,esm",
         "test": "ava"
     },
+    "dependencies": {
+        "unist-util-select": "^4.0.1"
+    },
+    "peerDependencies": {
+        "@mdx-js/mdx": "^2.0.0",
+        "react": ">=16.8.0"
+    },
     "devDependencies": {
         "@happy-dom/global-registrator": "^6.0.2",
+        "@mdx-js/mdx": "^2.1.2",
         "@testing-library/react": "^12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
         "@types/estree": "^0.0.52",
@@ -46,10 +54,6 @@
         "ts-node": "^10.8.2",
         "vfile": "^5.3.4"
     },
-    "dependencies": {
-        "@mdx-js/mdx": "^2.1.2",
-        "unist-util-select": "^4.0.1"
-    },
     "ava": {
         "extensions": {
             "ts": "module",
@@ -60,8 +64,5 @@
         "nodeArguments": [
             "--loader=ts-node/esm/transpile-only"
         ]
-    },
-    "peerDependencies": {
-        "react": ">=16.8.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,6 +1414,7 @@ __metadata:
     unist-util-select: ^4.0.1
     vfile: ^5.3.4
   peerDependencies:
+    "@mdx-js/mdx": ^2.0.0
     react: ">=16.8.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
@blocz/mdx-live depends on @mdx-js/mdx. But to avoid having a different version used by mdx-live and by mdx-live's users, I'm marking @mdx-js/mdx as a peer dependency.
