### PR TITLE
Re-include exports fields in scope in the `Provider`

### DIFF
--- a/packages/mdx-live/README.md
+++ b/packages/mdx-live/README.md
@@ -198,12 +198,12 @@ const resolveImport = async (option) => {
 };
 
 const App = () => {
-    const { scope, text, isReady } = useMDX({
+    const { resolvedImports, text, isReady } = useMDX({
         code: importMDX,
         resolveImport,
     });
 
-    // scope = Object containing all the top-level variables used in the MDX code (all imports & exports, in this case there is only `Button`)
+    // resolvedImports = Object containing all the resolved imports (in this case there is only `Button`)
     // text = parsed version of the MDX code without MDX nor JSX, aka plain code that can be executed
     // isReady: boolean representing if the code sample has been fully parsed yet or if it's still getting parsed
 };

--- a/packages/mdx-live/README.md
+++ b/packages/mdx-live/README.md
@@ -164,7 +164,40 @@ See https://mdxjs.com/packages/mdx/#optionsremarkplugins for more information.
 
 If you need to have access to more information in a custom renderer (like for instance a custom code block renderer), you can provide a `Provider` to `MDX`.
 
-The `Provider` will be provided the same data what [`useMDX`](#usemdx-hook) returns: `scope`, `text`, and `isReady`.
+`Provider` will be provided an object with:
+
+-   `text` and `isReady`, like [`useMDX`](#usemdx-hook)’s returned value,
+-   a `scope` object, which is a merge between:
+    -   the `defaultScope` prop,
+    -   resolved imports thanks to `resolveImport`,
+    -   exported values in the MDX.
+
+For instance, with the following example:
+
+```jsx
+<MDX
+    Provider={Provider}
+    defaultScope={{ variant: "blue" }}
+    code={`
+import { Button } from 'example';
+
+export const label = "Click Me!";
+
+<Button variant={variant} label={label} />
+`}
+    resolveImport={async () => ButtonVariable}
+/>
+```
+
+The `Provider` will be called with a `scope` of:
+
+```js
+{
+    Button: ButtonVariable,
+    label: "Click Me!",
+    variant: "blue",
+}
+```
 
 ### `useMDX` hook
 

--- a/packages/mdx-live/src/MDX.test.tsx
+++ b/packages/mdx-live/src/MDX.test.tsx
@@ -140,3 +140,45 @@ test("render MDX with import statement", async (t) => {
         );
     });
 });
+
+test("the Provider receives all imports and exports in its scope", async (t) => {
+    const Context = React.createContext<any>({});
+
+    const calls: any[] = [];
+    const Provider = (({ children, ...args }) => {
+        calls.push(args);
+        return <Context.Provider {...args}>{children}</Context.Provider>;
+    }) as typeof Context.Provider;
+
+    await act(async () => {
+        await render(
+            <MDX
+                code={mdxWithImportStatement}
+                resolveImport={resolveImport}
+                Provider={Provider}
+            />,
+        );
+        await wait(10);
+        t.is(1, calls.length);
+
+        t.is(true, calls[0].value.isReady);
+
+        t.deepEqual(
+            [
+                // Provided via import
+                "Button",
+                // Defined as exports
+                "InlineElement",
+                "AlternateButton",
+                "AlternateInlineButton",
+                "props",
+                "label",
+            ].sort(),
+            Object.keys(calls[0].value.scope).sort(),
+        );
+
+        // Check some of the variables
+        t.is("Click Me!", calls[0].value.scope.label);
+        t.is(Button, calls[0].value.scope.Button);
+    });
+});

--- a/packages/mdx-live/src/MDX.tsx
+++ b/packages/mdx-live/src/MDX.tsx
@@ -35,20 +35,24 @@ export const MDX: React.FunctionComponent<MDXProps> = ({
         remarkPlugins,
     });
 
-    const Runtime = React.useMemo(() => {
+    const compiled = React.useMemo(() => {
         if (!text) {
             return () => null;
         }
         const fn = new Function(text);
-        return fn(ReactRuntime).default;
+        return fn(ReactRuntime);
     }, [text]);
 
     if (!isReady) {
         return null;
     }
 
+    const { default: Runtime, ...otherExports } = compiled;
+
     return (
-        <Provider value={{ scope, text, isReady }}>
+        <Provider
+            value={{ scope: { ...scope, ...otherExports }, text, isReady }}
+        >
             <Runtime components={scope} />
         </Provider>
     );

--- a/packages/mdx-live/src/use-mdx.test.ts
+++ b/packages/mdx-live/src/use-mdx.test.ts
@@ -40,58 +40,13 @@ export const h = 1;
             F: "default",
             G: "default",
         } as Record<string, any>,
-        result.current.scope,
+        result.current.resolvedImports,
     );
 
     t.snapshot(result.current.text, "Text result");
     t.true(result.current.text.includes("\nconst h = 1;\n"));
 
     t.is(3, result.all.length); // 3 because: initial, compilation of the file, resolving of imports
-});
-
-test("it merges defaultScope and detected scope", async (t) => {
-    const { result, waitFor } = renderHook(() =>
-        useMDX({
-            code: `
-import A from 'a';
-`,
-            defaultScope: { b: "b" },
-        }),
-    );
-
-    await waitFor(() => result.current.text !== "");
-
-    t.deepEqual(
-        {
-            A: undefined,
-            b: "b",
-        } as Record<string, any>,
-        result.current.scope,
-    );
-});
-
-test("it keeps detected scope instead of defaultScope during conflicts", async (t) => {
-    const resolveImport = async () => {
-        return "detected";
-    };
-    const { result, waitFor } = renderHook(() =>
-        useMDX({
-            code: `
-import A from 'a';
-`,
-            defaultScope: { A: "default-scope" },
-            resolveImport,
-        }),
-    );
-
-    await waitFor(() => result.current.text !== "");
-
-    t.deepEqual(
-        {
-            A: "detected",
-        } as Record<string, any>,
-        result.current.scope,
-    );
 });
 
 test("it uses the most up-to-date resolveImport", async (t) => {
@@ -113,7 +68,7 @@ import A from 'a';
         {
             A: "initial",
         } as Record<string, any>,
-        result.current.scope,
+        result.current.resolvedImports,
     );
 
     resolveImport = async () => {
@@ -121,13 +76,13 @@ import A from 'a';
     };
     rerender();
     t.is(4, result.all.length);
-    await waitForValueToChange(() => result.current.scope);
+    await waitForValueToChange(() => result.current.resolvedImports);
 
     t.deepEqual(
         {
             A: "updated",
         } as Record<string, any>,
-        result.current.scope,
+        result.current.resolvedImports,
     );
     t.is(5, result.all.length); // switches from 4 to 5 so no useless re-renders
 });


### PR DESCRIPTION
## `useMDX`

- drop attribute `defaultScope`
- rename returned `scope` -> `resolvedImports`

## `MDX`

- In `Provider`, `scope` now contains all `export const …` again,
- Top level variable `React` is injected again in MDX
- Other fixes regarding scope in MDX resolution