### PR TITLE
Add types in exports

### DIFF
--- a/packages/mdx-live/package.json
+++ b/packages/mdx-live/package.json
@@ -1,10 +1,11 @@
 {
     "name": "@blocz/mdx-live",
     "version": "0.2.0-rc.8",
+    "type": "module",
     "source": "src/index.ts",
     "main": "lib/mdx-live.js",
     "module": "lib/mdx-live.js",
-    "type": "module",
+    "types": "lib/index.d.ts",
     "keywords": [
         "mdx",
         "markdown",
@@ -16,12 +17,12 @@
     ],
     "exports": {
         ".": {
+            "types": "./lib/index.d.ts",
             "import": "./lib/mdx-live.modern.js",
             "browser": "./lib/mdx-live.modern.js"
         },
         "./package.json": "./package.json"
     },
-    "types": "lib/index.d.ts",
     "repository": "git@github.com:bloczjs/mdx.git",
     "author": "Ayc0 <ayc0.benj@gmail.com>",
     "license": "MIT",

--- a/packages/mdx-plugin-detect-imports/package.json
+++ b/packages/mdx-plugin-detect-imports/package.json
@@ -1,21 +1,22 @@
 {
     "name": "@blocz/mdx-plugin-detect-imports",
     "version": "0.2.0-rc.8",
+    "type": "commonjs",
     "main": "src/plugin.cjs",
     "module": "src/plugin.mjs",
+    "types": "src/types.d.ts",
     "exports": {
         ".": {
+            "types": "./src/types.d.ts",
             "require": "./src/plugin.cjs",
             "import": "./src/plugin.mjs"
         },
         "./package.json": "./package.json"
     },
-    "types": "src/types.d.ts",
     "repository": "git@github.com:bloczjs/mdx.git",
     "author": "Ayc0 <ayc0.benj@gmail.com>",
     "license": "MIT",
     "sideEffects": false,
-    "type": "commonjs",
     "keywords": [
         "mdx",
         "markdown",


### PR DESCRIPTION
Starting in TS 4.7, when using `exports` fields, we need to also specify `types` in there (cf https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)