### PR TITLE
[react/jsx-runtime] remove extension from path for ESM React 18

### DIFF
--- a/packages/mdx-live/src/MDX.tsx
+++ b/packages/mdx-live/src/MDX.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import * as ReactRuntime from "react/jsx-runtime.js";
+import * as ReactRuntime from "react/jsx-runtime";
 
 import { useMDX, Variables } from "./use-mdx.js";
 import type { UseMDXParams, ResolveImport } from "./use-mdx";


### PR DESCRIPTION
Fixes:

```
Module not found: Error: Package path ./jsx-runtime.js is not exported from package node_modules/react/ (see exports field in node_modules/react/package.json)
```