### PR TITLE
update ava to v8

### DIFF
--- a/packages/mdx-live/package.json
+++ b/packages/mdx-live/package.json
@@ -58,12 +58,12 @@
         "vfile": "^6.0.3"
     },
     "ava": {
-        "extensions": {
-            "ts": "module",
-            "tsx": "module",
-            "mjs": true,
-            "cjs": true
-        },
+        "extensions": [
+            "ts",
+            "tsx",
+            "mjs",
+            "cjs"
+        ],
         "nodeArguments": [
             "--loader=ts-node/esm/transpile-only"
         ]

--- a/packages/mdx-live/package.json
+++ b/packages/mdx-live/package.json
@@ -50,7 +50,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/estree": "^1.0.9",
         "@types/react": "19.2.14",
-        "ava": "^7.0.0",
+        "ava": "^8.0.0",
         "microbundle": "^0.15.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",

--- a/packages/mdx-live/src/e2e.test.cjs
+++ b/packages/mdx-live/src/e2e.test.cjs
@@ -1,4 +1,4 @@
-const test = require("ava");
+const { default: test } = require("ava");
 
 test("@blocz/mdx-live works with CJS", async (t) => {
     const { MDX, useMDX } = await import("@blocz/mdx-live");

--- a/packages/mdx-plugin-detect-imports/package.json
+++ b/packages/mdx-plugin-detect-imports/package.json
@@ -38,6 +38,6 @@
     },
     "devDependencies": {
         "@mdx-js/mdx": "^3.1.1",
-        "ava": "^7.0.0"
+        "ava": "^8.0.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: 19.2.14
         version: 19.2.14
       ava:
-        specifier: ^7.0.0
-        version: 7.0.0(rollup@2.80.0)
+        specifier: ^8.0.0
+        version: 8.0.0(rollup@2.80.0)
       microbundle:
         specifier: ^0.15.0
         version: 0.15.1(ts-node@10.9.2(@types/node@25.6.2)(typescript@4.9.5))
@@ -80,8 +80,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       ava:
-        specifier: ^7.0.0
-        version: 7.0.0(rollup@4.60.3)
+        specifier: ^8.0.0
+        version: 8.0.0(rollup@4.60.3)
 
   tests/esbuild-test:
     dependencies:
@@ -102,8 +102,8 @@ importers:
         version: 19.2.6
     devDependencies:
       ava:
-        specifier: ^7.0.0
-        version: 7.0.0(rollup@4.60.3)
+        specifier: ^8.0.0
+        version: 8.0.0(rollup@4.60.3)
 
   tests/mdx-js-test:
     dependencies:
@@ -115,8 +115,8 @@ importers:
         version: 3.1.1
     devDependencies:
       ava:
-        specifier: ^7.0.0
-        version: 7.0.0(rollup@4.60.3)
+        specifier: ^8.0.0
+        version: 8.0.0(rollup@4.60.3)
 
   tests/rollup-test:
     dependencies:
@@ -137,8 +137,8 @@ importers:
         version: 4.60.3
     devDependencies:
       ava:
-        specifier: ^7.0.0
-        version: 7.0.0(rollup@4.60.3)
+        specifier: ^8.0.0
+        version: 8.0.0(rollup@4.60.3)
 
   tests/webpack-test:
     dependencies:
@@ -156,8 +156,8 @@ importers:
         version: 5.106.2
     devDependencies:
       ava:
-        specifier: ^7.0.0
-        version: 7.0.0(rollup@4.60.3)
+        specifier: ^8.0.0
+        version: 8.0.0(rollup@4.60.3)
 
 packages:
 
@@ -1442,9 +1442,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  ava@7.0.0:
-    resolution: {integrity: sha512-4sRJO/gehlfAgSbuH02mClDDiyymnuFmirE3KqPXl2pic1FaFTZaAACKqr85WT4o08iLjViMR9gmMkxzbZ3AgA==}
-    engines: {node: ^20.19 || ^22.20 || ^24.12 || >=25}
+  ava@8.0.0:
+    resolution: {integrity: sha512-KMUyT3LcnZ/5ipDAqnTGn6PQUvr1Jk4dex3v7ieQrGaMlAblfIpMLwK56HfPcObvJEzyhCWXfZjbM98FeAy0oQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
     hasBin: true
     peerDependencies:
       '@ava/typescript': '*'
@@ -1616,9 +1616,9 @@ packages:
   ci-parallel-vars@1.0.1:
     resolution: {integrity: sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==}
 
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
+  cli-truncate@6.0.0:
+    resolution: {integrity: sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==}
+    engines: {node: '>=22'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1839,9 +1839,9 @@ packages:
   electron-to-chromium@1.5.353:
     resolution: {integrity: sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==}
 
-  emittery@1.2.1:
-    resolution: {integrity: sha512-sFz64DCRjirhwHLxofFqxYQm6DCp6o0Ix7jwKQvuCHPn4GMRZNuBZyLPu9Ccmk/QSCAMZt6FOUqA8JZCQvA9fw==}
-    engines: {node: '>=14.16'}
+  emittery@2.0.0:
+    resolution: {integrity: sha512-FLtgn/CGBXiX3ZtPAm5q4LWWepHChOt55J9u01WFu3dyap2U7IwptlrqoE1COR/kxwdy/DOxIBALSxIW449I1g==}
+    engines: {node: '>=22'}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2561,9 +2561,9 @@ packages:
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
 
-  memoize@10.2.0:
-    resolution: {integrity: sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==}
-    engines: {node: '>=18'}
+  memoize@11.0.0:
+    resolution: {integrity: sha512-cjsfZaC9b1clqPeIVMbb5dLHSXgdgGWGxdAU3oTUUkHiwWTKTBNnSmcqWJncNjYtBi3S8Rp0c5GIiyGztR8TRA==}
+    engines: {node: '>=22'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3345,9 +3345,9 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5204,7 +5204,7 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  ava@7.0.0(rollup@2.80.0):
+  ava@8.0.0(rollup@2.80.0):
     dependencies:
       '@vercel/nft': 1.5.0(rollup@2.80.0)
       acorn: 8.16.0
@@ -5218,13 +5218,13 @@ snapshots:
       chunkd: 2.0.1
       ci-info: 4.4.0
       ci-parallel-vars: 1.0.1
-      cli-truncate: 5.2.0
+      cli-truncate: 6.0.0
       code-excerpt: 4.0.0
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
       debug: 4.4.3
-      emittery: 1.2.1
+      emittery: 2.0.0
       figures: 6.1.0
       globby: 16.2.0
       ignore-by-default: 2.1.0
@@ -5232,7 +5232,7 @@ snapshots:
       is-plain-object: 5.0.0
       is-promise: 4.0.0
       matcher: 6.0.0
-      memoize: 10.2.0
+      memoize: 11.0.0
       ms: 2.1.3
       p-map: 7.0.4
       package-config: 5.0.0
@@ -5240,6 +5240,7 @@ snapshots:
       plur: 6.0.0
       pretty-ms: 9.3.0
       resolve-cwd: 3.0.0
+      slash: 5.1.0
       stack-utils: 2.0.6
       supertap: 3.0.1
       temp-dir: 3.0.0
@@ -5250,7 +5251,7 @@ snapshots:
       - rollup
       - supports-color
 
-  ava@7.0.0(rollup@4.60.3):
+  ava@8.0.0(rollup@4.60.3):
     dependencies:
       '@vercel/nft': 1.5.0(rollup@4.60.3)
       acorn: 8.16.0
@@ -5264,13 +5265,13 @@ snapshots:
       chunkd: 2.0.1
       ci-info: 4.4.0
       ci-parallel-vars: 1.0.1
-      cli-truncate: 5.2.0
+      cli-truncate: 6.0.0
       code-excerpt: 4.0.0
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
       debug: 4.4.3
-      emittery: 1.2.1
+      emittery: 2.0.0
       figures: 6.1.0
       globby: 16.2.0
       ignore-by-default: 2.1.0
@@ -5278,7 +5279,7 @@ snapshots:
       is-plain-object: 5.0.0
       is-promise: 4.0.0
       matcher: 6.0.0
-      memoize: 10.2.0
+      memoize: 11.0.0
       ms: 2.1.3
       p-map: 7.0.4
       package-config: 5.0.0
@@ -5286,6 +5287,7 @@ snapshots:
       plur: 6.0.0
       pretty-ms: 9.3.0
       resolve-cwd: 3.0.0
+      slash: 5.1.0
       stack-utils: 2.0.6
       supertap: 3.0.1
       temp-dir: 3.0.0
@@ -5457,9 +5459,9 @@ snapshots:
 
   ci-parallel-vars@1.0.1: {}
 
-  cli-truncate@5.2.0:
+  cli-truncate@6.0.0:
     dependencies:
-      slice-ansi: 8.0.0
+      slice-ansi: 9.0.0
       string-width: 8.2.1
 
   cliui@8.0.1:
@@ -5704,7 +5706,7 @@ snapshots:
 
   electron-to-chromium@1.5.353: {}
 
-  emittery@1.2.1: {}
+  emittery@2.0.0: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6579,7 +6581,7 @@ snapshots:
 
   mdn-data@2.0.14: {}
 
-  memoize@10.2.0:
+  memoize@11.0.0:
     dependencies:
       mimic-function: 5.0.1
 
@@ -7580,7 +7582,7 @@ snapshots:
 
   slash@5.1.0: {}
 
-  slice-ansi@8.0.0:
+  slice-ansi@9.0.0:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0

--- a/tests/esbuild-test/package.json
+++ b/tests/esbuild-test/package.json
@@ -17,6 +17,6 @@
         "react": "^19.2.6"
     },
     "devDependencies": {
-        "ava": "^7.0.0"
+        "ava": "^8.0.0"
     }
 }

--- a/tests/mdx-js-test/package.json
+++ b/tests/mdx-js-test/package.json
@@ -14,6 +14,6 @@
         "@mdx-js/mdx": "^3.1.1"
     },
     "devDependencies": {
-        "ava": "^7.0.0"
+        "ava": "^8.0.0"
     }
 }

--- a/tests/rollup-test/package.json
+++ b/tests/rollup-test/package.json
@@ -17,6 +17,6 @@
         "rollup": "^4.60.3"
     },
     "devDependencies": {
-        "ava": "^7.0.0"
+        "ava": "^8.0.0"
     }
 }

--- a/tests/webpack-test/package.json
+++ b/tests/webpack-test/package.json
@@ -16,6 +16,6 @@
         "webpack": "^5.106.2"
     },
     "devDependencies": {
-        "ava": "^7.0.0"
+        "ava": "^8.0.0"
     }
 }

--- a/tests/webpack-test/webpack.test.js
+++ b/tests/webpack-test/webpack.test.js
@@ -1,7 +1,7 @@
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const os = require("node:os");
-const test = require("ava");
+const { default: test } = require("ava");
 const webpack = require("webpack");
 const detectImportsPlugin = require("@blocz/mdx-plugin-detect-imports");
 


### PR DESCRIPTION
closes https://github.com/bloczjs/mdx/pull/88: update ava to v8

- update `extensions` format,
- update `require("ava")` syntax