### PR TITLE
chore: add detect imports package metadata

### DIFF
--- a/packages/mdx-plugin-detect-imports/package.json
+++ b/packages/mdx-plugin-detect-imports/package.json
@@ -13,7 +13,15 @@
         },
         "./package.json": "./package.json"
     },
-    "repository": "git@github.com:bloczjs/mdx.git",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bloczjs/mdx.git",
+        "directory": "packages/mdx-plugin-detect-imports"
+    },
+    "bugs": {
+        "url": "https://github.com/bloczjs/mdx/issues"
+    },
+    "homepage": "https://github.com/bloczjs/mdx/tree/main/packages/mdx-plugin-detect-imports",
     "author": "Ayc0 <ayc0.benj@gmail.com>",
     "license": "MIT",
     "sideEffects": false,


### PR DESCRIPTION
## Summary
- add package-level repository metadata for `@blocz/mdx-plugin-detect-imports`
- add npm `bugs.url` and `homepage` links for the package
- keep runtime code, dependencies, version, exports, and package files unchanged

## Verification
- `node - <<'NODE' ... NODE` package metadata assertion
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @blocz/mdx-plugin-detect-imports test`
- `corepack pnpm format:check`